### PR TITLE
Makefile: various packaging enhancements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ $(MODIFY_TARGET): globals.h
 	$(MAKE) -C modify
 
 $(TARGET): $(OBJS) $(SDL_TARGET) data globals.h
-	$(CC) -o $(TARGET) $(OBJS) $(LDFLAGS) $(LIBS) $(SDL_TARGET)
+	$(CC) -o $(TARGET) $(OBJS) $(LDFLAGS) $(SDL_TARGET) $(LIBS)
 
 $(OBJS): globals.h
 

--- a/Makefile
+++ b/Makefile
@@ -46,10 +46,10 @@ install:
 	mkdir -p $(PREFIX)/bin/
 	mkdir -p $(PREFIX)/share/jumpnbump/
 	mkdir -p $(PREFIX)/share/man/man6/
-	install -o root -g root -m 755 $(BINARIES) $(PREFIX)/bin/
-	install -o root -g root -m 644 data/jumpbump.dat \
-	$(PREFIX)/share/jumpnbump/jumpbump.dat
-	install -o root -g root -m 644 jumpnbump.6 $(PREFIX)/share/man/man6/
+	install -m 755 $(BINARIES) $(PREFIX)/bin/
+	install -m 644 data/jumpbump.dat \
+		$(PREFIX)/share/jumpnbump/jumpbump.dat
+	install -m 644 jumpnbump.6 $(PREFIX)/share/man/man6/
 
 uninstall:
 	cd $(PREFIX)/bin && rm -f $(BINARIES)

--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,10 @@ PREFIX ?= /usr/local
 all: $(BINARIES)
 
 $(SDL_TARGET): globals.h
-	cd sdl && make
+	$(MAKE) -C sdl
 
 $(MODIFY_TARGET): globals.h
-	cd modify && make
+	$(MAKE) -C modify
 
 $(TARGET): $(OBJS) $(SDL_TARGET) data globals.h
 	$(CC) -o $(TARGET) $(OBJS) $(LIBS) $(SDL_TARGET)
@@ -34,13 +34,11 @@ jnbmenu.tcl: jnbmenu.pre
 	sed -e "s#%%PREFIX%%#$(PREFIX)#g" < jnbmenu.pre > jnbmenu.tcl
 
 data: jnbpack
-	cd data && make
+	$(MAKE) -C data
 
 clean:
-	cd sdl && make clean
-	cd modify && make clean
-	cd data && make clean
-	rm -f $(TARGET) *.o globals.h jnbmenu.tcl
+	for dir in data modify sdl; do $(MAKE) clean -C $$dir; done
+	$(RM) $(TARGET) *.o globals.h jnbmenu.tcl
 
 install:
 	mkdir -p $(PREFIX)/bin/
@@ -52,9 +50,9 @@ install:
 	install -m 644 jumpnbump.6 $(PREFIX)/share/man/man6/
 
 uninstall:
-	cd $(PREFIX)/bin && rm -f $(BINARIES)
-	rm -rf $(PREFIX)/share/jumpnbump
-	rm -f $(PREFIX)/share/man/man6/jumpnbump.6
+	for bin in $(BINARIES); do $(RM) $(PREFIX)/bin/$$bin; done
+	$(RM) -r $(PREFIX)/share/jumpnbump
+	$(RM) $(PREFIX)/share/man/man6/jumpnbump.6
 
 doc:
 	rman jumpnbump.6 -f HTML >jumpnbump.html

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,22 @@
+PREFIX ?= /usr/local
+
+CFLAGS ?= -Wall -O2 -ffast-math -funroll-loops
 SDL_CFLAGS = `sdl2-config --cflags`
+DEFINES = -Dstricmp=strcasecmp -Dstrnicmp=strncasecmp -DNDEBUG -DUSE_SDL -DUSE_NET -DZLIB_SUPPORT -DBZLIB_SUPPORT
+INCLUDES = -I.
+CFLAGS += $(DEFINES) $(SDL_CFLAGS) $(INCLUDES)
+export CFLAGS
+
+LDFLAGS ?=
 SDL_LIBS = `sdl2-config --libs`
-CFLAGS = -Wall -O2 -ffast-math -funroll-loops -Dstricmp=strcasecmp \
-	-Dstrnicmp=strncasecmp -DUSE_SDL -DNDEBUG -I. $(SDL_CFLAGS) \
-	-DUSE_NET -DZLIB_SUPPORT -DBZLIB_SUPPORT
 LIBS = -lm $(SDL_LIBS) -lSDL2_mixer -lSDL2_net -lbz2 -lz
+
+TARGET = jumpnbump
 SDL_TARGET = sdl.a
 MODIFY_TARGET = gobpack jnbpack jnbunpack
 OBJS = main.o menu.o filter.o network.o
-TARGET = jumpnbump
 BINARIES = $(TARGET) jumpnbump.svgalib jumpnbump.fbcon $(MODIFY_TARGET) \
 	jnbmenu.tcl
-PREFIX ?= /usr/local
 
 .PHONY: data
 
@@ -23,7 +29,7 @@ $(MODIFY_TARGET): globals.h
 	$(MAKE) -C modify
 
 $(TARGET): $(OBJS) $(SDL_TARGET) data globals.h
-	$(CC) -o $(TARGET) $(OBJS) $(LIBS) $(SDL_TARGET)
+	$(CC) -o $(TARGET) $(OBJS) $(LDFLAGS) $(LIBS) $(SDL_TARGET)
 
 $(OBJS): globals.h
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,9 @@
+DESTDIR ?=
 PREFIX ?= /usr/local
+BINDIR ?= $(PREFIX)/bin
+DATADIR ?= $(PREFIX)/share
+# Can be overridden to use e.g. /usr/share/games
+GAMEDATADIR ?= $(DATADIR)
 
 CFLAGS ?= -Wall -O2 -ffast-math -funroll-loops
 SDL_CFLAGS = `sdl2-config --cflags`
@@ -34,10 +39,10 @@ $(TARGET): $(OBJS) $(SDL_TARGET) data globals.h
 $(OBJS): globals.h
 
 globals.h: globals.pre
-	sed -e "s#%%PREFIX%%#$(PREFIX)#g" < globals.pre > globals.h
+	sed -e "s#%%DATADIR%%#$(GAMEDATADIR)#g" < globals.pre > globals.h
 
 jnbmenu.tcl: jnbmenu.pre
-	sed -e "s#%%PREFIX%%#$(PREFIX)#g" < jnbmenu.pre > jnbmenu.tcl
+	sed -e "s#%%BINDIR%%#$(BINDIR)#g" -e "s#%%DATADIR%%#$(GAMEDATADIR)#g" < jnbmenu.pre > jnbmenu.tcl
 
 data: jnbpack
 	$(MAKE) -C data
@@ -47,18 +52,18 @@ clean:
 	$(RM) $(TARGET) *.o globals.h jnbmenu.tcl
 
 install:
-	mkdir -p $(PREFIX)/bin/
-	mkdir -p $(PREFIX)/share/jumpnbump/
-	mkdir -p $(PREFIX)/share/man/man6/
-	install -m 755 $(BINARIES) $(PREFIX)/bin/
+	mkdir -p $(DESTDIR)$(BINDIR)
+	mkdir -p $(DESTDIR)$(GAMEDATADIR)/jumpnbump/
+	mkdir -p $(DESTDIR)$(DATADIR)/man/man6/
+	install -m 755 $(BINARIES) $(DESTDIR)$(BINDIR)/
 	install -m 644 data/jumpbump.dat \
-		$(PREFIX)/share/jumpnbump/jumpbump.dat
-	install -m 644 jumpnbump.6 $(PREFIX)/share/man/man6/
+		$(DESTDIR)$(GAMEDATADIR)/jumpnbump/jumpbump.dat
+	install -m 644 jumpnbump.6 $(DESTDIR)$(DATADIR)/man/man6/
 
 uninstall:
-	for bin in $(BINARIES); do $(RM) $(PREFIX)/bin/$$bin; done
-	$(RM) -r $(PREFIX)/share/jumpnbump
-	$(RM) $(PREFIX)/share/man/man6/jumpnbump.6
+	for bin in $(BINARIES); do $(RM) $(DESTDIR)$(BINDIR)/$$bin; done
+	$(RM) -r $(DESTDIR)$(GAMEDATADIR)/jumpnbump
+	$(RM) $(DESTDIR)$(DATADIR)/man/man6/jumpnbump.6
 
 doc:
-	rman jumpnbump.6 -f HTML >jumpnbump.html
+	rman jumpnbump.6 -f HTML > jumpnbump.html

--- a/data/Makefile
+++ b/data/Makefile
@@ -21,7 +21,7 @@ jumpbump.dat: $(DATAFILES) ../jnbpack
 	../jnbpack -o jumpbump.dat $(DATAFILES)
 
 ../jnbpack:
-	cd ../modify && make
+	$(MAKE) -C ../modify
 
 clean:
-	rm -f jumpbump.dat $(GOBS)
+	$(RM) jumpbump.dat $(GOBS)

--- a/data/Makefile
+++ b/data/Makefile
@@ -1,5 +1,5 @@
-GOBS = numbers.gob objects.gob rabbit.gob
-DATAFILES = bump.mod calib.dat death.smp fly.smp font.gob jump.mod \
+GOBS = font.gob numbers.gob objects.gob rabbit.gob
+DATAFILES = bump.mod calib.dat death.smp fly.smp jump.mod \
 	jump.smp levelmap.txt level.pcx mask.pcx menu.pcx \
 	menumask.pcx $(GOBS) scores.mod splash.smp spring.smp
 

--- a/globals.pre
+++ b/globals.pre
@@ -170,7 +170,7 @@ extern int ai[JNB_MAX_PLAYERS];
 #elif _WIN32
 #define	DATA_PATH "data/jumpbump.dat"
 #else
-#define	DATA_PATH "%%PREFIX%%/share/jumpnbump/jumpbump.dat"
+#define	DATA_PATH "%%DATADIR%%/jumpnbump/jumpbump.dat"
 #endif
 #endif
 

--- a/jnbmenu.pre
+++ b/jnbmenu.pre
@@ -45,14 +45,14 @@ global fullscreen
 
 	set file ""
 	if { [ .top17.lis26 curselection ] != "" } then {
-		set file "%%PREFIX%%/bin/jumpnbump/[ .top17.lis26 get [.top17.lis26 curselection] ].dat"
+		set file "%%BINDIR%%/jumpnbump/[ .top17.lis26 get [.top17.lis26 curselection] ].dat"
 	}
 	
 	exec jumpnbump $str_fullscreen $str_nosound $str_scaleup $str_mirror $str_nogore -dat $file &
 }
 
 proc {fill_list_box} {} {
-if [ catch { exec ls %%PREFIX%%/share/jumpnbump/ } data ] {
+if [ catch { exec ls %%DATADIR%%/jumpnbump/ } data ] {
 		puts stderr "Error"
 	}
 

--- a/modify/Makefile
+++ b/modify/Makefile
@@ -18,4 +18,4 @@ all: $(TARGETS)
 	$(CC) $(CFLAGS) -o ../jnbunpack $(LIBS) jnbunpack.c
 
 clean:
-	rm -f $(TARGETS) $(OBJS)
+	$(RM) $(TARGETS) $(OBJS)

--- a/modify/Makefile
+++ b/modify/Makefile
@@ -1,21 +1,20 @@
-CFLAGS = -Wall -ansi -pedantic -O2 -ffast-math -funroll-loops \
-	-Dstricmp=strcasecmp -Dstrnicmp=strncasecmp -DNDEBUG \
-	-I. -I.. -DUSE_NET -D_DEFAULT_SOURCE
+CFLAGS += -I..
+# Override libs, SDL2 not needed
 LIBS = -lm
-SRCS = gobpack.c jnbpack.c jnbunpack.c
+
 OBJS = gobpack.o jnbpack.o jnbunpack.o
 TARGETS = ../gobpack ../jnbpack ../jnbunpack
 
 all: $(TARGETS)
 
 ../gobpack: gobpack.c
-	$(CC) $(CFLAGS) -o ../gobpack $(LIBS) gobpack.c
+	$(CC) $(CFLAGS) -o ../gobpack $(LDFLAGS) $(LIBS) gobpack.c
 
 ../jnbpack: jnbpack.c
-	$(CC) $(CFLAGS) -o ../jnbpack $(LIBS) jnbpack.c
+	$(CC) $(CFLAGS) -o ../jnbpack $(LDFLAGS) $(LIBS) jnbpack.c
 
 ../jnbunpack: jnbunpack.c
-	$(CC) $(CFLAGS) -o ../jnbunpack $(LIBS) jnbunpack.c
+	$(CC) $(CFLAGS) -o ../jnbunpack $(LDFLAGS) $(LIBS) jnbunpack.c
 
 clean:
 	$(RM) $(TARGETS) $(OBJS)

--- a/sdl/Makefile
+++ b/sdl/Makefile
@@ -9,8 +9,8 @@ TARGET = ../sdl.a
 all: $(TARGET)
 
 $(TARGET): $(OBJS)
-	ar cru $(TARGET) $(OBJS)
+	$(AR) cru $(TARGET) $(OBJS)
 	ranlib $(TARGET)
 
 clean:
-	rm -f $(TARGET) $(OBJS)
+	$(RM) $(TARGET) $(OBJS)

--- a/sdl/Makefile
+++ b/sdl/Makefile
@@ -1,7 +1,4 @@
-SDL_CFLAGS = `sdl2-config --cflags`
-CFLAGS = -Wall -ansi -pedantic -O2 -ffast-math -funroll-loops \
-	-Dstricmp=strcasecmp -Dstrnicmp=strncasecmp -DNDEBUG \
-	-I. -I.. $(SDL_CFLAGS) -DUSE_SDL -DUSE_NET
+CFLAGS += -I..
 
 OBJS = gfx.o interrpt.o sound.o input.o
 TARGET = ../sdl.a


### PR DESCRIPTION
The commits should be relatively self-explanatory, they add support for:
- CFLAGS and LDFLAGS env variables used by packagers to enforce their optimisation flags, linking flags, etc.
- DESTDIR, the classical variable packagers know that they can use to define the installation target (e.g. RPM_BUILD_ROOT).
- Configurable BINDIR (for distros using `/usr/games` for game binaries) and GAMEDATADIR (for distros using `/usr/share/games/<pkg>` for game data), and DATADIR for the sake of consistency (used for the man dir, and in the future we can add a desktop file, an icon, etc. in this path).