### PR TITLE
Add support for building Windows binaries with mingw-w64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,9 @@
 .directory
 .DS_Store
 
-# Jump'n'bump generated files
+# Jump 'n Bump generated files
+*.dll
+*.exe
 *.o
 data/*.gob
 data/jumpbump.dat

--- a/Makefile
+++ b/Makefile
@@ -4,21 +4,24 @@ BINDIR ?= $(PREFIX)/bin
 DATADIR ?= $(PREFIX)/share
 # Can be overridden to use e.g. /usr/share/games
 GAMEDATADIR ?= $(DATADIR)
+EXE ?=
 
 CFLAGS ?= -Wall -O2 -ffast-math -funroll-loops
 SDL_CFLAGS = `sdl2-config --cflags`
 DEFINES = -Dstricmp=strcasecmp -Dstrnicmp=strncasecmp -DNDEBUG -DUSE_SDL -DUSE_NET -DZLIB_SUPPORT -DBZLIB_SUPPORT
 INCLUDES = -I.
 CFLAGS += $(DEFINES) $(SDL_CFLAGS) $(INCLUDES)
-export CFLAGS
+export SDL_CFLAGS
+export DEFINES
+export INCLUDES
 
 LDFLAGS ?=
 SDL_LIBS = `sdl2-config --libs`
 LIBS = -lm $(SDL_LIBS) -lSDL2_mixer -lSDL2_net -lbz2 -lz
 
-TARGET = jumpnbump
+TARGET = jumpnbump$(EXE)
 SDL_TARGET = sdl.a
-MODIFY_TARGET = gobpack jnbpack jnbunpack
+MODIFY_TARGET = gobpack$(EXE) jnbpack$(EXE) jnbunpack$(EXE)
 OBJS = main.o menu.o filter.o network.o
 BINARIES = $(TARGET) $(MODIFY_TARGET) jnbmenu.tcl
 
@@ -43,12 +46,12 @@ globals.h: globals.pre
 jnbmenu.tcl: jnbmenu.pre
 	sed -e "s#%%BINDIR%%#$(BINDIR)#g" -e "s#%%DATADIR%%#$(GAMEDATADIR)#g" < jnbmenu.pre > jnbmenu.tcl
 
-data: jnbpack
+data: jnbpack$(EXE)
 	$(MAKE) -C data
 
 clean:
 	for dir in data modify sdl; do $(MAKE) clean -C $$dir; done
-	$(RM) $(TARGET) *.o globals.h jnbmenu.tcl
+	$(RM) $(TARGET) *.exe *.o globals.h jnbmenu.tcl
 
 install:
 	mkdir -p $(DESTDIR)$(BINDIR)

--- a/build-mingw.sh
+++ b/build-mingw.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+BITS=32
+
+if [[ $# -ge 1 ]]; then
+  case "$1" in
+    --help|-h)
+    echo "Usage: <script> [options]"
+    echo -e "\nAvailable options:"
+    echo -e "\t--help, -h\tThis usage explanation."
+    echo -e "\t--32\t\tBuild 32-bit binary with MinGW-w64."
+    echo -e "\t--64\t\tBuild 64-bit binary with MinGW-w64."
+    echo ""
+    exit 0
+    ;;
+    --32)
+    BITS=32
+    ;;
+    --64)
+    BITS=64
+    ;;
+    *)
+    echo "Unknown option, use --help for usage instructions."
+    ;;
+  esac
+  shift
+fi
+
+if [ "${BITS}" == "32" ]; then
+    MINGW=i686-w64-mingw32
+    LIBS="libgcc_s_sjlj-1 "
+else
+    MINGW=x86_64-w64-mingw32
+fi
+
+MINGW_PATH=/usr/${MINGW}
+PATH=${MINGW_PATH}/bin:${MINGW_PATH}/sys-root/mingw/bin:${PATH}; echo ${PATH}
+CC=${MINGW}-gcc
+
+make CC=${CC} EXEC=wine EXE=.exe $@
+
+LIBS+="libbz2-1 libFLAC-8 libmodplug-1 libogg-0 libstdc++-6 libvorbis-0 libvorbisfile-3 libwinpthread-1 SDL2 SDL2_mixer SDL2_net zlib1"
+for lib in ${LIBS}; do
+  cp -f ${MINGW_PATH}/sys-root/mingw/bin/${lib}.dll .
+done

--- a/data/Makefile
+++ b/data/Makefile
@@ -1,3 +1,7 @@
+EXEC ?= exec
+
+GOBPACK = ../gobpack$(EXE)
+JNBPACK = ../jnbpack$(EXE)
 GOBS = font.gob numbers.gob objects.gob rabbit.gob
 DATAFILES = bump.mod calib.dat death.smp fly.smp jump.mod \
 	jump.smp levelmap.txt level.pcx mask.pcx menu.pcx \
@@ -6,21 +10,21 @@ DATAFILES = bump.mod calib.dat death.smp fly.smp jump.mod \
 all: jumpbump.dat
 
 font.gob:
-	../gobpack font
+	$(EXEC) $(GOBPACK) font
 
 rabbit.gob:
-	../gobpack rabbit
+	$(EXEC) $(GOBPACK) rabbit
 
 numbers.gob:
-	../gobpack numbers
+	$(EXEC) $(GOBPACK) numbers
 
 objects.gob:
-	../gobpack objects
+	$(EXEC) $(GOBPACK) objects
 
-jumpbump.dat: $(DATAFILES) ../jnbpack
-	../jnbpack -o jumpbump.dat $(DATAFILES)
+jumpbump.dat: $(DATAFILES) $(JNBPACK)
+	$(EXEC) $(JNBPACK) -o jumpbump.dat $(DATAFILES)
 
-../jnbpack:
+$(JNBPACK):
 	$(MAKE) -C ../modify
 
 clean:

--- a/globals.pre
+++ b/globals.pre
@@ -38,7 +38,7 @@ extern "C" {
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#ifndef _MSC_VER
+#ifndef _WIN32
 #include <strings.h>
 #endif
 #include <time.h>
@@ -52,7 +52,7 @@ extern "C" {
 # include <pc.h>
 #endif
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 # define WIN32_LEAN_AND_MEAN
 # include <windows.h>
 # include <sys/stat.h>

--- a/main.c
+++ b/main.c
@@ -27,7 +27,7 @@
 
 #include "globals.h"
 #include <fcntl.h>
-#ifndef _MSC_VER
+#ifndef _WIN32
 #include <unistd.h>
 #endif
 
@@ -237,7 +237,7 @@ int pogostick, bunnies_in_space, jetpack, lord_of_the_flies, blood_is_thicker_th
 
 int client_player_num = -1;
 
-#ifndef _MSC_VER
+#ifndef _WIN32
 int filelength(int handle)
 {
 	struct stat buf;
@@ -2659,7 +2659,7 @@ void deinit_program(void)
 
 	if (main_info.error_str[0] != 0) {
 		printf("%s", main_info.error_str);
-#ifdef _MSC_VER
+#ifdef _WIN32
 		MessageBox(0, main_info.error_str, "Jump 'n Bump", 0);
 #endif
 		exit(1);

--- a/modify/Makefile
+++ b/modify/Makefile
@@ -1,20 +1,24 @@
-CFLAGS += -I..
+INCLUDES += -I..
+CFLAGS += $(DEFINES) $(INCLUDES)
 # Override libs, SDL2 not needed
 LIBS = -lm
 
 OBJS = gobpack.o jnbpack.o jnbunpack.o
-TARGETS = ../gobpack ../jnbpack ../jnbunpack
+GOBPACK = ../gobpack$(EXE)
+JNBPACK = ../jnbpack$(EXE)
+JNBUNPACK = ../jnbunpack$(EXE)
+TARGETS = $(GOBPACK) $(JNBPACK) $(JNBUNPACK)
 
 all: $(TARGETS)
 
-../gobpack: gobpack.c
-	$(CC) $(CFLAGS) -o ../gobpack $(LDFLAGS) $(LIBS) gobpack.c
+$(GOBPACK): gobpack.c
+	$(CC) $(CFLAGS) -o $(GOBPACK) $(LDFLAGS) $(LIBS) gobpack.c
 
-../jnbpack: jnbpack.c
-	$(CC) $(CFLAGS) -o ../jnbpack $(LDFLAGS) $(LIBS) jnbpack.c
+$(JNBPACK): jnbpack.c
+	$(CC) $(CFLAGS) -o $(JNBPACK) $(LDFLAGS) $(LIBS) jnbpack.c
 
-../jnbunpack: jnbunpack.c
-	$(CC) $(CFLAGS) -o ../jnbunpack $(LDFLAGS) $(LIBS) jnbunpack.c
+$(JNBUNPACK): jnbunpack.c
+	$(CC) $(CFLAGS) -o $(JNBUNPACK) $(LDFLAGS) $(LIBS) jnbunpack.c
 
 clean:
 	$(RM) $(TARGETS) $(OBJS)

--- a/modify/jnbpack.c
+++ b/modify/jnbpack.c
@@ -32,7 +32,7 @@
 #ifdef LINUX
 #include <getopt.h>
 #endif
-#ifndef _MSC_VER
+#ifndef _WIN32
 #include <unistd.h>
 #else
 #include <io.h>

--- a/modify/jnbunpack.c
+++ b/modify/jnbunpack.c
@@ -28,7 +28,7 @@
 #include <fcntl.h>
 #include <string.h>
 #include <sys/types.h>
-#ifndef _MSC_VER
+#ifndef _WIN32
 #include <unistd.h>
 #else
 #include <io.h>

--- a/sdl/Makefile
+++ b/sdl/Makefile
@@ -1,4 +1,5 @@
-CFLAGS += -I..
+INCLUDES += -I..
+CFLAGS += $(DEFINES) $(SDL_CFLAGS) $(INCLUDES)
 
 OBJS = gfx.o interrpt.o sound.o input.o
 TARGET = ../sdl.a

--- a/sdl/gfx.c
+++ b/sdl/gfx.c
@@ -29,7 +29,7 @@
 #include "SDL_endian.h"
 #include "filter.h"
 
-#ifdef _MSC_VER
+#ifdef _WIN32
     #include "jumpnbump32.xpm"
 #elif __APPLE__
     #include "jumpnbump128.xpm"

--- a/sdl/interrpt.c
+++ b/sdl/interrpt.c
@@ -28,7 +28,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
-#ifndef _MSC_VER
+#ifndef _WIN32
 #include <unistd.h>
 #endif
 #include "globals.h"

--- a/sdl/sound.c
+++ b/sdl/sound.c
@@ -25,7 +25,7 @@
 
 #include "globals.h"
 #include <limits.h>
-#ifndef _MSC_VER
+#ifndef _WIN32
 #include <unistd.h>
 #endif
 #include "SDL.h"
@@ -463,7 +463,7 @@ char dj_ready_mod(char mod_num)
 {
 #ifndef NO_SDL_MIXER
 	FILE *tmp;
-# if ((defined _MSC_VER) || (defined __MINGW32__))
+# ifdef _WIN32
 	char filename[] = "jnb.tmpmusic.mod";
 # else
 	char filename[] = "/tmp/jnb.tmpmusic.mod";


### PR DESCRIPTION
Fixes #16.

This only allows building Windows binaries from Linux, but it shouldn't be too hard to tweak things further to allow building with MinGW-w64 on Windows, or to make a VS project.